### PR TITLE
thread search query - tweaked return object to include comments

### DIFF
--- a/src/db/search/search.threads.ts
+++ b/src/db/search/search.threads.ts
@@ -29,6 +29,7 @@ export async function queryPublicThreads(
         likes: (result.likes && Object.entries(result.likes).length) || 0,
         shares: (result.shares && Object.entries(result.shares).length) || 0,
         updatedAt: result.updatedAt,
+        comments: result.comments && Object.values(result.comments),
       };
     });
   }
@@ -74,6 +75,7 @@ export async function queryPrivateThreads(
           likes: (result.likes && Object.entries(result.likes).length) || 0,
           shares: (result.shares && Object.entries(result.shares).length) || 0,
           updatedAt: result.updatedAt,
+          comments: result.comments && Object.values(result.comments),
         };
       });
     }

--- a/src/db/search/search.types.ts
+++ b/src/db/search/search.types.ts
@@ -1,3 +1,4 @@
+import { IThreadComment } from "../../models/thread-comment/thread-comment.types";
 import { ThreadType, ThreadVisibility } from "../../models/thread/thread.types";
 
 export interface ISearchResults {
@@ -36,6 +37,7 @@ export interface IThreadDetails {
     hashTags?: Array<string>;
     attachments?: Array<string>;
   };
+  comments?: Array<IThreadComment>;
   visibility: ThreadVisibility;
   likes?: number;
   shares?: number;

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,7 +66,7 @@ app.get("/fail", (req, res) => {
 });
 const port = app.get("port");
 const server = app.listen(port, () =>
-  console.log(`Server started on port ${port}`)
+  console.log(`Server started on ports ${port}`)
 );
 
 export default server;


### PR DESCRIPTION
- Adds `comments` to the threadResults in order to render other details in the actual result card.