### PR TITLE
added timestamp to thread model

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+*.json
+*.yml
+*.md
+node_modules
+package.json

--- a/src/models/thread/thread-test-helper/thread-test-helper.ts
+++ b/src/models/thread/thread-test-helper/thread-test-helper.ts
@@ -5,12 +5,12 @@ import mongoose from "mongoose";
 const lorem = new LoremIpsum({
   sentencesPerParagraph: {
     max: 8,
-    min: 4
+    min: 4,
   },
   wordsPerSentence: {
     max: 16,
-    min: 4
-  }
+    min: 4,
+  },
 });
 
 /**
@@ -18,7 +18,10 @@ const lorem = new LoremIpsum({
  * @param count number of users to create
  * @param forUserId userId
  */
-export function createDummyPublicThreads(count: number, forUserId: string): IThread[] {
+export function createDummyPublicThreads(
+  count: number,
+  forUserId: string
+): IThread[] {
   const createdThreads: IThread[] = [];
   for (let i = 0; i < count; i++) {
     createdThreads.push({
@@ -28,13 +31,15 @@ export function createDummyPublicThreads(count: number, forUserId: string): IThr
       content: {
         html: lorem.generateParagraphs(2),
         hashTags: [],
-        attachments: []
+        attachments: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
       },
-      comments: { },
-      likes: { },
-      shares: { },
+      comments: {},
+      likes: {},
+      shares: {},
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
   }
   return createdThreads;

--- a/src/models/thread/thread.methods.ts
+++ b/src/models/thread/thread.methods.ts
@@ -61,6 +61,7 @@ export async function patchThread(
         new Set(targetThread.content.attachments)
       );
     }
+    targetThread.content.updatedAt = new Date();
     return await targetThread.save();
   }
   throw new Error("Thread not found");

--- a/src/models/thread/thread.methods.ts
+++ b/src/models/thread/thread.methods.ts
@@ -1,4 +1,8 @@
-import { IThreadDocument, IThreadModel, IThreadPatchData } from "./thread.types";
+import {
+  IThreadDocument,
+  IThreadModel,
+  IThreadPatchData,
+} from "./thread.types";
 import mongoose from "mongoose";
 import { ThreadModel } from "./thread.model";
 /**
@@ -6,9 +10,17 @@ import { ThreadModel } from "./thread.model";
  * @param this *
  * @param excludeUserId userId of posts to exclude from the return
  */
-export async function getAllPublicThreads(this: IThreadModel, excludePostedByUserIds?: string[]): Promise<IThreadDocument[]> {
+export async function getAllPublicThreads(
+  this: IThreadModel,
+  excludePostedByUserIds?: string[]
+): Promise<IThreadDocument[]> {
   if (excludePostedByUserIds) {
-    return await this.find({ visibility: 0 , postedByUserId: { $nin: excludePostedByUserIds.map(id => mongoose.Types.ObjectId(id)) } }).exec();
+    return await this.find({
+      visibility: 0,
+      postedByUserId: {
+        $nin: excludePostedByUserIds.map((id) => mongoose.Types.ObjectId(id)),
+      },
+    }).exec();
   }
   return await this.find({ visibility: 0 }).exec();
 }
@@ -17,13 +29,17 @@ export async function getAllPublicThreads(this: IThreadModel, excludePostedByUse
  * Updates info on a thread document (used in patch route)
  * @param threadPatchData
  */
-export async function patchThread(this: IThreadModel, data: IThreadPatchData): Promise<IThreadDocument> {
+export async function patchThread(
+  this: IThreadModel,
+  data: IThreadPatchData
+): Promise<IThreadDocument> {
   const targetThread = await ThreadModel.findById(data.threadId);
 
-  if (targetThread ) {
+  if (targetThread) {
     if (data.userId.toString() !== targetThread.postedByUserId.toString()) {
       throw new Error("Unauthorized patch request");
     }
+
     if (data.threadType) {
       targetThread.threadType = data.threadType;
     }
@@ -35,11 +51,15 @@ export async function patchThread(this: IThreadModel, data: IThreadPatchData): P
     }
     if (data.hashTags) {
       targetThread.content.hashTags = [...data.hashTags];
-      targetThread.content.hashTags = Array.from(new Set(targetThread.content.hashTags));
+      targetThread.content.hashTags = Array.from(
+        new Set(targetThread.content.hashTags)
+      );
     }
     if (data.attachments) {
       targetThread.content.attachments = [...data.attachments];
-      targetThread.content.attachments = Array.from(new Set(targetThread.content.attachments));
+      targetThread.content.attachments = Array.from(
+        new Set(targetThread.content.attachments)
+      );
     }
     return await targetThread.save();
   }

--- a/src/models/thread/thread.model.test.ts
+++ b/src/models/thread/thread.model.test.ts
@@ -2,8 +2,13 @@ import mongoose from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
 let mongoServer: any;
 
-import { IThread, IThreadPatchData, ThreadType, ThreadVisibility } from "./thread.types";
-import { ThreadModel }  from "./thread.model";
+import {
+  IThread,
+  IThreadPatchData,
+  ThreadType,
+  ThreadVisibility,
+} from "./thread.types";
+import { ThreadModel } from "./thread.model";
 import { createDummyPublicThreads } from "./thread-test-helper/thread-test-helper";
 import { createTestUsers } from "../user/user-test-helper/user-test-helper";
 import { UserModel } from "../user/user.model";
@@ -39,12 +44,14 @@ describe("CRUD operations for Thread model", () => {
         html: "someSampleHTML",
         hashTags: ["#hashTag1", "#hashTag2"],
         attachments: ["a1490dfw4", "b90d*hd*734"],
+        createdAt: new Date(),
+        updatedAt: new Date(),
       },
-      comments: { },
-      likes: { },
-      shares: { },
+      comments: {},
+      likes: {},
+      shares: {},
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     };
 
     const result = await ThreadModel.create(testThreadData);
@@ -56,9 +63,9 @@ describe("CRUD operations for Thread model", () => {
     expect(result.content.attachments[1]).toBe("b90d*hd*734");
   });
   describe("getAllPublicThread tests", () => {
-    test("get all public threads returns public threads", async() => {
+    test("get all public threads returns public threads", async () => {
       // Create a user
-      const testUsers = createTestUsers({ numberOfUsers: 10});
+      const testUsers = createTestUsers({ numberOfUsers: 10 });
       const dummyUserDocuments = await UserModel.create(testUsers);
 
       // Create some threads
@@ -68,27 +75,40 @@ describe("CRUD operations for Thread model", () => {
       const resultingFlattenedThreads = _.flatten(dummyThreads);
       expect(resultingFlattenedThreads).toHaveLength(10);
     });
-    test("get all public threads where the thread creator is excluded", async() => {
-      const testUsers = createTestUsers({ numberOfUsers: 2});
+    test("get all public threads where the thread creator is excluded", async () => {
+      const testUsers = createTestUsers({ numberOfUsers: 2 });
       const dummyUserDocuments = await UserModel.create(testUsers);
 
-      const user1DummyThreads = createDummyPublicThreads(2, dummyUserDocuments[0].id);
-      const user2DummyThreads = createDummyPublicThreads(2, dummyUserDocuments[1].id);
+      const user1DummyThreads = createDummyPublicThreads(
+        2,
+        dummyUserDocuments[0].id
+      );
+      const user2DummyThreads = createDummyPublicThreads(
+        2,
+        dummyUserDocuments[1].id
+      );
       await ThreadModel.create(user1DummyThreads);
       await ThreadModel.create(user2DummyThreads);
-      const results = await ThreadModel.getAllPublicThreads([dummyUserDocuments[0].id]);
+      const results = await ThreadModel.getAllPublicThreads([
+        dummyUserDocuments[0].id,
+      ]);
 
       expect(results).toHaveLength(3);
-      expect(results.filter((result) => {
-        return result.postedByUserId === dummyUserDocuments[0].id;
-      })).toHaveLength(0);
+      expect(
+        results.filter((result) => {
+          return result.postedByUserId === dummyUserDocuments[0].id;
+        })
+      ).toHaveLength(0);
     });
   });
   describe("thread patch tests", () => {
-    test("updates (patching) to thread performs correctly", async() => {
-      const testUsers = createTestUsers({ numberOfUsers: 2});
+    test("updates (patching) to thread performs correctly", async () => {
+      const testUsers = createTestUsers({ numberOfUsers: 2 });
       const dummyUserDocuments = await UserModel.create(testUsers);
-      const dummyThread1 = createDummyPublicThreads(2, dummyUserDocuments[0].id);
+      const dummyThread1 = createDummyPublicThreads(
+        2,
+        dummyUserDocuments[0].id
+      );
       const createdThreads = await ThreadModel.create(dummyThread1);
 
       expect(createdThreads[0].visibility).toBe(ThreadVisibility.Anyone);
@@ -100,28 +120,34 @@ describe("CRUD operations for Thread model", () => {
         visibility: ThreadVisibility.Connections,
         threadType: ThreadType.Photo,
         attachments: ["https://some-photo.com/photo1"],
-        hashTags: ["#tag1", "#tag2", "#tag2"]
+        hashTags: ["#tag1", "#tag2", "#tag2"],
       };
       const patchedThread = await ThreadModel.patchThread(patchData);
       expect(patchedThread.content.html).toBe("some kind of new content here");
       expect(patchedThread.content.hashTags).toHaveLength(2);
       expect(patchedThread.content.hashTags[1]).toBe("#tag2");
       expect(patchedThread.visibility).toBe(ThreadVisibility.Connections);
-      expect(patchedThread.content.attachments[0]).toBe("https://some-photo.com/photo1");
+      expect(patchedThread.content.attachments[0]).toBe(
+        "https://some-photo.com/photo1"
+      );
       expect(patchedThread.threadType).toBe(ThreadType.Photo);
     });
   });
-  test("patch thread function throws when user tries to patch a thread that they didn't author"
-  , async() => {
-    const testUsers = createTestUsers({ numberOfUsers: 2});
+  test("patch thread function throws when user tries to patch a thread that they didn't author", async () => {
+    const testUsers = createTestUsers({ numberOfUsers: 2 });
     const dummyUserDocuments = await UserModel.create(testUsers);
-    const dummyThreadForUser2 = createDummyPublicThreads(2, dummyUserDocuments[1].id);
+    const dummyThreadForUser2 = createDummyPublicThreads(
+      2,
+      dummyUserDocuments[1].id
+    );
     const createdThreads = await ThreadModel.create(dummyThreadForUser2);
 
     const patchData: IThreadPatchData = {
       threadId: createdThreads[0].id,
       userId: dummyUserDocuments[0].id,
     };
-    await expect(() => ThreadModel.patchThread(patchData)).rejects.toThrow("Unauthorized patch request");
+    await expect(() => ThreadModel.patchThread(patchData)).rejects.toThrow(
+      "Unauthorized patch request"
+    );
   });
 });

--- a/src/models/thread/thread.schema.ts
+++ b/src/models/thread/thread.schema.ts
@@ -1,33 +1,42 @@
 import { Schema, Types } from "mongoose";
 import { getAllPublicThreads, patchThread } from "./thread.methods";
 
-const ThreadSchema: Schema = new Schema({
-  postedByUserId: { type: Types.ObjectId, required: true },
-  threadType: { type: String, default: "post"},
-  visibility: { type: Number, default: 0 },
-  content: {
+const ThreadSchema: Schema = new Schema(
+  {
+    postedByUserId: { type: Types.ObjectId, required: true },
+    threadType: { type: String, default: "post" },
+    visibility: { type: Number, default: 0 },
+    content: {
       html: { type: String },
       hashTags: { type: [String], default: [] },
-      attachments: { type: [String], default: []}
+      attachments: { type: [String], default: [] },
+      createdAt: { type: Date, default: Date.now },
+      updatedAt: { type: Date, default: Date.now },
+    },
+    comments: {
+      type: Schema.Types.Mixed,
+      default: {},
+      required: true,
+    },
+    likes: {
+      type: Schema.Types.Mixed,
+      default: {},
+      required: true,
+    },
+    shares: {
+      type: Schema.Types.Mixed,
+      default: {},
+      required: true,
+    },
   },
-  comments: {
-    type: Schema.Types.Mixed,
-    default: { },
-    required: true,
-  },
-  likes: {
-    type: Schema.Types.Mixed,
-    default: { },
-    required: true,
-  },
-  shares: {
-    type: Schema.Types.Mixed,
-    default: { },
-    required: true,
-  }
-}, { timestamps: { }} );
+  { timestamps: {} }
+);
 
-ThreadSchema.index({ "content.html": "text", "content.hashTags": "text", "comments": "text" });
+ThreadSchema.index({
+  "content.html": "text",
+  "content.hashTags": "text",
+  "comments": "text",
+});
 ThreadSchema.statics.getAllPublicThreads = getAllPublicThreads;
 ThreadSchema.statics.patchThread = patchThread;
 export default ThreadSchema;

--- a/src/models/thread/thread.types.ts
+++ b/src/models/thread/thread.types.ts
@@ -8,12 +8,12 @@ export enum ThreadType {
   Post = "post",
   Photo = "photo",
   Job = "job",
-  Article = "article"
+  Article = "article",
 }
 
 export enum ThreadVisibility {
   Anyone = 0,
-  Connections = 1
+  Connections = 1,
 }
 
 export interface IThreadPostDetails {
@@ -29,9 +29,11 @@ export interface IThread {
   threadType: ThreadType;
   visibility: ThreadVisibility;
   content: {
-    html: string,
-    hashTags: Array<string>,
-    attachments: Array<string>
+    html: string;
+    hashTags: Array<string>;
+    attachments: Array<string>;
+    readonly createdAt: Date;
+    readonly updatedAt: Date;
   };
   comments: { [keyof: string]: IThreadComment };
   likes: { [keyof: string]: IThreadLikeDocument };
@@ -50,8 +52,14 @@ export interface IThreadPatchData {
   attachments?: Array<string>;
 }
 
-export interface IThreadDocument extends IThread, Document { }
+export interface IThreadDocument extends IThread, Document {}
 export interface IThreadModel extends Model<IThreadDocument> {
-  getAllPublicThreads: (this: IThreadModel, excludeUserIds?: string[]) => Promise<IThreadDocument[]>;
-  patchThread: (this: IThreadModel, data: IThreadPatchData) => Promise<IThreadDocument>;
+  getAllPublicThreads: (
+    this: IThreadModel,
+    excludeUserIds?: string[]
+  ) => Promise<IThreadDocument[]>;
+  patchThread: (
+    this: IThreadModel,
+    data: IThreadPatchData
+  ) => Promise<IThreadDocument>;
 }

--- a/src/models/thread/thread.types.ts
+++ b/src/models/thread/thread.types.ts
@@ -33,7 +33,7 @@ export interface IThread {
     hashTags: Array<string>;
     attachments: Array<string>;
     readonly createdAt: Date;
-    readonly updatedAt: Date;
+    updatedAt: Date;
   };
   comments: { [keyof: string]: IThreadComment };
   likes: { [keyof: string]: IThreadLikeDocument };

--- a/src/models/user/user.thread/user.thread.methods.ts
+++ b/src/models/user/user.thread/user.thread.methods.ts
@@ -35,6 +35,8 @@ export async function createAndPostThread(
       html: sanitizeHtml(threadDetails.html),
       attachments: threadDetails.attachments,
       hashTags: threadDetails.hashTags,
+      updatedAt: new Date(),
+      createdAt: new Date(),
     },
     comments: {},
     likes: {},


### PR DESCRIPTION
- Adds a timestamp (`createdAt`, `updatedAt`) fields to the `content` property in the `Thread` schema. Updated types. Some linting fixes.
resolves: https://github.com/chingu-voyages/v25-bears-team-05/issues/116