### PR TITLE
Get thread by getThreadById for each user thread

### DIFF
--- a/src/models/user/user.thread/user.thread.methods.ts
+++ b/src/models/user/user.thread/user.thread.methods.ts
@@ -17,6 +17,7 @@ import {
   IThreadShareDocument,
 } from "../../../models/thread-share/thread-share.types";
 import { deleteUserCommentsForThreadByThreadId } from "./user.thread.deletion.methods";
+import { getThreadById } from "../../../db/utils/get-thread-by-id/get-thread-by-id";
 
 /**
  *
@@ -91,11 +92,13 @@ export async function getConnectionThreads(
     .exec();
   const threads: IThread[] = [];
 
-  users.forEach((user) => {
+  await Promise.all(users.map(async (user) => {
     for (const [_, value] of Object.entries(user.threads.started)) {
-      threads.push(value);
+      const threadData = await getThreadById({ threadId: value._id })
+      threads.push(threadData);
     }
-  });
+    return 
+  }));
 
   return threads.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf());
 }


### PR DESCRIPTION
Addresses [issue #140](https://github.com/chingu-voyages/v25-bears-team-05/issues/140)
I originally just fixed adding/removing the like document to the thread creators user data. But then I realised this only handles updating the liker user and the thread poster. Others who've previously commented or liked the thread will have stale data.
For now I've simply changed the getThreadById method to only use the user thread data ids (to call getThreadById). For now with any other issues like this we could default to using the duplicates as references only until we revise a better strategy.
